### PR TITLE
Fixed prototype extends models to the particular extend model.

### DIFF
--- a/backbone-model-file-upload.js
+++ b/backbone-model-file-upload.js
@@ -20,7 +20,7 @@
   var backboneModelClone = _.clone( Backbone.Model.prototype );
 
   // Extending out
-  _.extend(Backbone.Model.prototype, {
+  var FileModel = Backbone.Model.extend({
 
     // ! Default file attribute - can be overwritten
     fileAttribute: 'file',
@@ -130,4 +130,8 @@
 
   });
 
+  //Exports
+  Backbone.FileModel = FileModel;
+  
+  return FileModel;
 }));


### PR DESCRIPTION
That will be able to extend a particular class.
For example:

```
define([
    'backbone-model-file-upload'
], function(
    FileModel
) {
    'use strict';

    var CsvFileModel = Backbone.FileModel.extend({
              // Or you can use: CsvFileModel = FileModel.extend ...
        });
});

```

After this code CsvFileModel will be able to save files. Now we have to connect backbone-model-file-upload extend all models of project — it's wrong way, and came across this approach to unexpected errors of the common method 'save()'.

Sorry for my bad English.
