### PR TITLE
handle FileList objects

### DIFF
--- a/backbone-model-file-upload.js
+++ b/backbone-model-file-upload.js
@@ -60,6 +60,7 @@
            || options.formData !== false 
               && mergedAttrs[ this.fileAttribute ] 
               && mergedAttrs[ this.fileAttribute ] instanceof File
+              || mergedAttrs[ this.fileAttribute ] instanceof FileList
               || mergedAttrs[ this.fileAttribute ] instanceof Blob ) {
         
         // Flatten Attributes reapplying File Object
@@ -71,6 +72,12 @@
         // Converting Attributes to Form Data
         var formData = new FormData();
         _.each( formAttrs, function( value, key ){
+          if (value instanceof FileList) {
+            _.each(value, function(file) {
+              formData.append( key, file );
+            });
+            return;
+          }
           formData.append( key, value );
         });
 


### PR DESCRIPTION
Recurse FileList objects from file inputs with multiple files and add all the files, this will generate an array on the server when getting the fileattribute key.

I use this in Flask (python) as an example:
files = request.files.getlist('files')

Which returns when using fileAtrribute: 'files':
[<FileStorage: u'file1.png' ('image/png')>, <FileStorage: u'file2.png' ('image/png')>]
