### PR TITLE
Fixes wrong arguments order for factory function

### DIFF
--- a/backbone-model-file-upload.js
+++ b/backbone-model-file-upload.js
@@ -18,7 +18,7 @@
   // NodeJS/CommonJS
   } else if (typeof exports !== 'undefined') {
     var _ = require('underscore'), $ = require('jquery'), Backbone = require('backbone');
-    factory(root, _, $, Backbone);
+    factory(root, Backbone, _, $);
 
   // Browser global
   } else {


### PR DESCRIPTION
When using this Backbone extension with Browserify it won't work because the arguments order for the factory function is ordered wrong. This fixes this issue.