### PR TITLE
Moved dependencies to devDependancies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,16 +6,7 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {
-    "bower": "^1.3.12",
-    "formidable": "~1.0.15",
-    "grunt": "^0.4.5",
-    "grunt-contrib-jasmine": "^0.6.5",
-    "grunt-run": "^0.3.0",
-    "grunt-run-node": "^0.1.0",
-    "grunt-template-jasmine-requirejs": "^0.2.0",
-    "lodash": "~2.4.1"
-  },
+  "dependencies": {},
   "scripts": {
     "test": "grunt test"
   },
@@ -36,5 +27,14 @@
     "url": "https://github.com/homeslicesolutions/backbone-model-file-upload/issues"
   },
   "homepage": "https://github.com/homeslicesolutions/backbone-model-file-upload",
-  "devDependencies": {}
+  "devDependencies": {
+    "bower": "^1.3.12",
+    "formidable": "~1.0.15",
+    "grunt": "^0.4.5",
+    "grunt-contrib-jasmine": "^0.6.5",
+    "grunt-run": "^0.3.0",
+    "grunt-run-node": "^0.1.0",
+    "grunt-template-jasmine-requirejs": "^0.2.0",
+    "lodash": "~2.4.1"
+  }
 }


### PR DESCRIPTION
The dependencies listed in the package.json are actually devDependencies, and not required to install the main script.