### PR TITLE
Added array handling for file upload

### DIFF
--- a/backbone-model-file-upload.js
+++ b/backbone-model-file-upload.js
@@ -90,9 +90,15 @@
             _.each(value, function(file) {
               formData.append( key, file );
             });
-            return;
           }
-          formData.append( key, value );
+          else if (value instanceof Array && value.length && value[0] instanceof File) {
+            _.each(value, function(file) {
+              formData.append( key, file );
+            });
+          }
+          else {
+            formData.append( key, value );
+          }
         });
 
         // Set options for AJAX call
@@ -102,11 +108,11 @@
 
         // Handle "progress" events
         var that = this;
-        var beforeSend = options.beforeSend;
-        options.beforeSend = function(xhr){
-          xhr.upload.addEventListener('progress', that._progressHandler.bind(that), false);
-          if(beforeSend) {
-            return beforeSend.apply(this, arguments);
+        if (!options.xhr) {
+          options.xhr = function(){
+            var xhr = Backbone.$.ajaxSettings.xhr();
+            xhr.upload.addEventListener('progress', that._progressHandler.bind(that), false);
+            return xhr
           }
         }
       }

--- a/backbone-model-file-upload.js
+++ b/backbone-model-file-upload.js
@@ -43,7 +43,8 @@
     save: function(key, val, options) {
 
       // Variables
-      var attrs, attributes = this.attributes;
+      var attrs, attributes = this.attributes,
+          that = this;
 
       // Signature parsing - taken directly from original Backbone.Model.save
       // and it states: 'Handle both "key", value and {key: value} -style arguments.'
@@ -86,12 +87,7 @@
         // Converting Attributes to Form Data
         var formData = new FormData();
         _.each( formAttrs, function( value, key ){
-          if (value instanceof FileList) {
-            _.each(value, function(file) {
-              formData.append( key, file );
-            });
-          }
-          else if (value instanceof Array && value.length && value[0] instanceof File) {
+          if (value instanceof FileList || (key === that.fileAttribute && value instanceof Array)) {
             _.each(value, function(file) {
               formData.append( key, file );
             });
@@ -107,11 +103,10 @@
         options.contentType = false;
 
         // Handle "progress" events
-        var that = this;
         if (!options.xhr) {
           options.xhr = function(){
             var xhr = Backbone.$.ajaxSettings.xhr();
-            xhr.upload.addEventListener('progress', that._progressHandler.bind(that), false);
+            xhr.upload.addEventListener('progress', _.bind(that._progressHandler, that), false);
             return xhr
           }
         }

--- a/test/backbone-model-file-upload.spec.js
+++ b/test/backbone-model-file-upload.spec.js
@@ -18,10 +18,12 @@
 
     var fileModel;
     var simulatedFileObj;
+    var simulatedFileObj2;
 
     beforeEach(function(){
 
       simulatedFileObj = new Blob(['<strong>Hello World</strong>'], {type : 'text/html'});
+      simulatedFileObj2 = new Blob(['<strong>Hello Again, World</strong>'], {type : 'text/html'});
 
       fileModel = new File({
         from: 'sample@email.com',
@@ -42,13 +44,13 @@
     });
 
     it('should detect the file(blob) save successfully', function(done){
-      
+
       // Arrange
       fileModel.set({fileAttachment: simulatedFileObj});
 
       // Listen
       fileModel.on('sync', function(model){
-        
+
         // Assert
         expect(model.get('from')).toBe('sample@email.com');
 
@@ -70,7 +72,7 @@
 
       // Listen
       fileModel.on('sync', function(model){
-        
+
         // Assert
         expect(model.get('from')).toBe('sample@email.com');
 
@@ -92,7 +94,6 @@
 
       // Listen
       fileModel.on('sync', function(model){
-        
         // Assert
         expect(model.get('from')).toBe('sample@email.com');
         // Assert Blob (phantomJS can't do Blobs so just test minimal attributes)
@@ -109,11 +110,33 @@
 
     });
 
+    it ('should be able to save an array of multiple file objects', function(done){
+    // Listen
+    fileModel.on('sync', function(model){
+        // Assert
+        expect(model.get('from')).toBe('sample@email.com');
+
+        // Assert Blob (phantomJS can't do Blobs so just test minimal attributes)
+        expect(model.get('fileAttachment')[0].size).toBe(28);
+        expect(model.get('fileAttachment')[0].type).toBe('text/html');
+        //expect(model.get('fileAttachment')[0].data).toBe('data:text/html;base64,PHN0cm9uZz5IZWxsbyBXb3JsZDwvc3Ryb25nPg==')
+        expect(model.get('fileAttachment')[1].size).toBe(35);
+        expect(model.get('fileAttachment')[1].type).toBe('text/html');
+        //expect(model.get('fileAttachment')[1].data).toBe('data:text/html;base64,PHN0cm9uZz5IZWxsbyBBZ2FpbiwgV29ybGQ8L3N0cm9uZz4K=')
+
+        done();
+
+      });
+
+      // Act
+      fileModel.save('fileAttachment', [simulatedFileObj, simulatedFileObj2], {formData: true});
+    });
+
     it ('should be able to have "wait" and "validate" option', function(done){
 
       // Listen
       fileModel.on('sync', function(model){
-        
+
         // Assert
         expect(model.get('from')).toBe('sample@email.com');
         // Assert Blob (phantomJS can't do Blobs so just test minimal attributes)
@@ -134,7 +157,7 @@
 
       // Listen
       fileModel.on('sync', function(model){
-        
+
         // Assert
         expect(model.get('from')).toBe('somethingelse@email.com');
         //expect(model.get('fileAttachment').data).toBe('data:text/html;base64,PHN0cm9uZz5IZWxsbyBXb3JsZDwvc3Ryb25nPg==');
@@ -153,7 +176,7 @@
 
       // Listen
       fileModel.on('sync', function(model){
-        
+
         // Assert
         expect(model.get('from')).toBe('yes');
         //expect(model.get('fileAttachment').data).toBe('data:text/html;base64,PHN0cm9uZz5IZWxsbyBXb3JsZDwvc3Ryb25nPg==');
@@ -171,7 +194,7 @@
 
       // Listen
       fileModel.on('sync', function(model){
-        
+
         // Assert
         expect(model.get('from')).toBe('yes');
         //expect(model.get('fileAttachment').data).toBe('data:text/html;base64,PHN0cm9uZz5IZWxsbyBXb3JsZDwvc3Ryb25nPg==');
@@ -191,7 +214,7 @@
 
       // Listen
       fileModel.on('sync', function(model){
-        
+
         // Assert
         // Assert Blob (phantomJS can't do Blobs so just test minimal attributes)
         expect(model.get('fileAttachment').size).toBe(28);
@@ -220,7 +243,7 @@
 
       // Listen
       fileModel.on('sync', function(model){
-        
+
         // Assert
         expect(model.get('from')).toBe('yes');
 
@@ -268,7 +291,7 @@
 
       expect(_.isEqual(unflattened, fileModel.toJSON())).toBeTruthy();
 
-      console.log(fileModel._flatten({
+      console.log(JSON.stringify(fileModel._flatten({
         'family': 'The Smiths',
         'grandpa': {
           'name': 'Ole Joe Smith',
@@ -287,7 +310,7 @@
             }
           ]
         }
-      }));
+      })));
 
     });
 


### PR DESCRIPTION
I added handling of `Array`s in the fileAttribute field, instead of just `FileList`s, because a user cannot create a `FileList`, so if they wanted to upload multiple files from multiple different file inputs, it would not work. The use case for this in my case is I have a single file upload field for a form, and the user can drop/add/remove as many files to it as they want, and when they submit the form, I need to be able to upload all those files.

Additionally, this commit contains a fix for `jQuery > 1.5.1`. I would have liked to have it in a different pull request, but I needed it for my testing. Just pull that code if you want it, or remove it if you don't.

Finally, this contains some updates to the test server and test script. Test script basically just added a test, but I also added the capability for the test server to echo multiple files in an array, instead of only single files. It still doesn't work for me because `formidable` doesn't get the files correctly (they are of length 0 for some reason), but the logic is sound.
